### PR TITLE
Fix ratelimit env variable docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ FLASK_ENV=production  # Use 'development' for local development
 
 # Rate Limiting
 RATELIMIT_DEFAULT='100 per day'
-RATELIMIT_STORAGE_URL='redis://localhost:6379/0'
+RATELIMIT_STORAGE_URI='redis://localhost:6379/0'
 
 # Database Configuration
 DATABASE_URL='postgresql://[username]:[password]@[host]:[port]/[database]'

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ FLASK_ENV=production
 
 # Rate Limiting
 RATELIMIT_DEFAULT=100 per day
-RATELIMIT_STORAGE_URL=redis://localhost:6379/0
+RATELIMIT_STORAGE_URI=redis://localhost:6379/0
 
 # MongoDB Configuration
 MONGODB_URI=your_mongodb_connection_string


### PR DESCRIPTION
## Summary
- update README to reference `RATELIMIT_STORAGE_URI`
- align example environment file with updated name

## Testing
- `pytest -q` *(fails: command not found)*