### PR TITLE
Center footer text on pages without menu

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -998,7 +998,7 @@ textarea::placeholder {
 /* Footer */
 .page-footer {
     display: flex;
-    justify-content: space-between; /* Space between copyright and menu */
+    justify-content: center; /* Center footer content by default */
     align-items: center;
     padding: var(--spacing-sm) var(--spacing-lg);
     color: var(--text-secondary);
@@ -1015,6 +1015,10 @@ textarea::placeholder {
     max-width: 1000px;
     margin: 0 auto;
     box-sizing: border-box;
+}
+
+.page-footer.with-menu {
+    justify-content: space-between; /* Space between copyright and menu */
 }
 
 .copyright {

--- a/app/templates/auth/change_password.html
+++ b/app/templates/auth/change_password.html
@@ -90,7 +90,7 @@
         </div>
     </div>
     
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/auth/conversations.html
+++ b/app/templates/auth/conversations.html
@@ -104,7 +104,7 @@
         </div>
     </div>
     
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/auth/edit_profile.html
+++ b/app/templates/auth/edit_profile.html
@@ -95,7 +95,7 @@
         </div>
     </div>
     
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/auth/profile.html
+++ b/app/templates/auth/profile.html
@@ -109,7 +109,7 @@
         </div>
     </div>
     
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -96,7 +96,7 @@
         </div>
     </div>
 
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/privacy_policy.html
+++ b/app/templates/privacy_policy.html
@@ -118,7 +118,7 @@
         </main>
     </div>
 
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">

--- a/app/templates/terms_of_service.html
+++ b/app/templates/terms_of_service.html
@@ -130,7 +130,7 @@
         </main>
     </div>
 
-    <footer class="page-footer">
+    <footer class="page-footer with-menu">
         <p class="copyright">&copy; <span id="current-year"></span> JANE - Job Assistance and Navigation Expert</p>
         <div class="footer-menu">
             <button id="show-menu" class="menu-button" aria-label="Show menu">


### PR DESCRIPTION
## Summary
- center footer text by default in CSS
- keep space between items only when a menu is present
- mark pages that include a footer menu

## Testing
- `pytest -q` *(fails: command not found)*