### PR TITLE
Fix footer centering

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1018,7 +1018,8 @@ textarea::placeholder {
 }
 
 .page-footer.with-menu {
-    justify-content: space-between; /* Space between copyright and menu */
+    justify-content: center; /* Center text even with footer menu */
+    position: relative; /* Allow absolutely positioned menu */
 }
 
 .copyright {
@@ -1029,6 +1030,8 @@ textarea::placeholder {
 .footer-menu {
     display: flex;
     align-items: center;
+    position: absolute;
+    right: var(--spacing-lg);
 }
 
 .menu-button {


### PR DESCRIPTION
## Summary
- center footer text when footer menu is present
- absolutely position footer menu on the right side

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*